### PR TITLE
Fix debug build

### DIFF
--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -18,6 +18,7 @@ namespace dev
 namespace eth
 {
 Farm* Farm::m_this = nullptr;
+const int Farm::m_collectInterval;
 
 Farm::Farm(map<string, DeviceDescriptor>& _DevicesCollection, FarmSettings _settings)
   : m_Settings(move(_settings)),


### PR DESCRIPTION
When building without optimizations, I currently get `error: undefined reference to 'dev::eth::Farm::m_collectInterval'`.
This happens because [`m_collectInterval`](https://github.com/no-fee-ethereum-mining/nsfminer/blob/c3dd064e949fc6ecafd08d5f6100aa85c2f0dec5/libethcore/Farm.h#L231) is odr-used ([1](https://github.com/no-fee-ethereum-mining/nsfminer/blob/c3dd064e949fc6ecafd08d5f6100aa85c2f0dec5/libethcore/Farm.cpp#L127), [2](https://github.com/no-fee-ethereum-mining/nsfminer/blob/c3dd064e949fc6ecafd08d5f6100aa85c2f0dec5/libethcore/Farm.cpp#L572)) since `boost::posix_time::milliseconds()` accepts its argument by reference, so it has to have an address.
Without an explicit definition of the variable the compiler doesn't emit it in any of the translation units, hence the error, but on higher optimization levels it lets us get away with it most likely because it optimizes the function away.

Here I add an explicit definition to help with this little odr violation.