### PR TITLE
Fix h256 layout

### DIFF
--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -18,12 +18,6 @@ template <unsigned N>
 class FixedHash
 {
 public:
-#if defined(_WIN32)
-    const char* k_ellipsis = "...";
-#else
-    const char* k_ellipsis = "\342\200\246";
-#endif
-
     /// The corresponding arithmetic type.
     using Arith = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<N * 8, N * 8,
         boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
@@ -187,7 +181,15 @@ public:
 
     /// @returns an abridged version of the hash as a user-readable hex string.
 
-    std::string abridged() const { return toHex(ref().cropped(0, 4)) + k_ellipsis; }
+    std::string abridged() const {
+#if defined(_WIN32)
+        const char* ellipsis = "...";
+#else
+        const char* ellipsis = "\342\200\246";
+#endif
+
+        return toHex(ref().cropped(0, 4)) + ellipsis;
+    }
 
     /// @returns the hash as a user-readable hex string.
     std::string hex(HexPrefix _prefix = HexPrefix::DontAdd) const { return toHex(ref(), 2, _prefix); }


### PR DESCRIPTION
It looks like h256 is assumed to have the layout of a 32 byte array, judging by these lines
https://github.com/no-fee-ethereum-mining/nsfminer/blob/ecda1665cd17243310a44cf836920b656e86d7e9/libethash-cl/CLMiner.cpp#L392
https://github.com/no-fee-ethereum-mining/nsfminer/blob/ecda1665cd17243310a44cf836920b656e86d7e9/libethash-cuda/CUDAMiner.cpp#L384
While there is a 32 byte array as a data member, there is also a pointer `h256::k_ellipsis` in front of the array, and on my machine `sizeof(h256) == 40`.

That pointer doesn't need to be there. So here I move it to the only place where it's used, making `sizeof(h256) == 32` and, by extension, `sizeof(FixedHash<N>) == N`.