### PR TITLE
Fix stack-use-after-scope

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -349,7 +349,7 @@ void CLMiner::workLoop()
 
                 // Update header constant buffer.
                 m_queue[0].enqueueWriteBuffer(
-                    m_header[0], CL_FALSE, 0, w.header.size, w.header.data());
+                    m_header[0], CL_TRUE, 0, w.header.size, w.header.data());
                 // zero the result count
                 m_queue[0].enqueueWriteBuffer(m_searchBuffer[0], CL_FALSE,
                     offsetof(SearchResults, count), sizeof(zerox3), zerox3);


### PR DESCRIPTION
This bug is from running the address sanitizer, full report is attached.

Essentially, a non-blocking `enqueueWriteBuffer` call is issued to write to a buffer from the host memory without any synchronization, so it might try to read from `w` after `w` goes out of scope, which is not good.

Here I convert the call to be blocking, like it's done a couple lines earlier in the file when dealing with the host memory.
https://github.com/no-fee-ethereum-mining/nsfminer/blob/053c807fe563df2113d06198a1d8a3c80e0e4b9e/libethash-cl/CLMiner.cpp#L304-L315
[address-sanitizer-report.txt](https://github.com/no-fee-ethereum-mining/nsfminer/files/5854245/address-sanitizer-report.txt)
