### PR TITLE
Remove an unnecessary volatile specifier

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -296,7 +296,7 @@ void CLMiner::workLoop()
         {
 
             // Read results.
-            volatile SearchResults results;
+            SearchResults results;
 
             if (m_queue.size())
             {


### PR DESCRIPTION
While doing something else, I noticed that this `volatile` does nothing except make the compiler sad.
I can sort of see the logic behind putting it there: "this memory can change under me", but this is not the case volatile was designed for. Here, the pointer into the `results` variable is given to `enqueueReadBuffer` to write the result into, no volatile required. It's just an out parameter.
Besides, had the `volatile` really been required, they would've annotated the pointer with a `volatile` specifier in the function declaration itself.