### PR TITLE
Make build c++17-capable

### DIFF
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -42,7 +42,7 @@ bytes dev::fromHex(string const& _s, WhenError _throw)
         int h = fromHex(_s[i], WhenError::DontThrow);
         int l = fromHex(_s[i + 1], WhenError::DontThrow);
         if (h != -1 && l != -1)
-            ret.push_back((byte)(h * 16 + l));
+            ret.push_back((::byte)(h * 16 + l));
         else if (_throw == WhenError::Throw)
             BOOST_THROW_EXCEPTION(BadHexCharacter());
         else


### PR DESCRIPTION
It's unfortunate that there's a name clash between `std::byte` and
https://github.com/no-fee-ethereum-mining/nsfminer/blob/6ef343bab13fc36989931cdb80bfafb7e0f51a2b/libdevcore/Common.h#L10
Maybe it's worth it to rename it in the future or make `::byte` an alias for `std::byte` in editions starting with c++17 abseil-style. The latter might require a fair bit of massaging the code because `std::byte` doesn't support a lot of operations.

For now I'd like to be able to build in c++17 mode.
One caveat is that I'm not compiling cuda code as I don't have that kinda device, so some incompatibilities might still be lurking in there.