### PR TITLE
Fix compiler errors and warnings

### DIFF
--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -754,9 +754,16 @@ public:
 
         m_FarmSettings.hwMon = vm["HWMON"].as<unsigned>();
         m_FarmSettings.eval = vm.count("eval");
+
+#if ETH_ETHASHCUDA
         m_FarmSettings.cuBlockSize = vm["cu-block"].as<unsigned>();
         m_FarmSettings.cuStreams = vm["cu-streams"].as<unsigned>();
+#endif
+
+#if ETH_ETHASHCL
         m_FarmSettings.clGroupSize = vm["cl-work"].as<unsigned>();
+#endif
+
         m_FarmSettings.tempStop = vm["tstop"].as<unsigned>();
         m_FarmSettings.tempStart = vm["tstart"].as<unsigned>();
 


### PR DESCRIPTION
As I usually build without API_CORE support, all references to `m_api_bind`, `m_api_port`, etc result in build errors, so they should be guarded by `#if API_CORE`.

I also moved `on_*` functions higher up in the file so they could also be guarded by respective `#if`s, otherwise I get compiler warnings like `'warning: 'void on_cu_streams(unsigned int)' defined but not used` or `warning: 'void on_api_port(int)' defined but not used`.