### PR TITLE
Add pciDomainID support for ppc64le systems

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -240,8 +240,9 @@ void CUDAMiner::enumDevices(map<string, DeviceDescriptor>& _DevicesCollection)
             size_t freeMem, totalMem;
             CUDA_CALL(cudaGetDeviceProperties(&props, i));
             CUDA_CALL(cudaMemGetInfo(&freeMem, &totalMem));
-            s << setw(2) << setfill('0') << hex << props.pciBusID << ":" << setw(2)
-              << props.pciDeviceID << ".0";
+            s << setw(4) << setfill('0') << hex << props.pciDomainID << ":" 
+              << setw(2) << setfill('0') << hex << props.pciBusID << ":"
+              << setw(2) << props.pciDeviceID << ".0";
             uniqueId = s.str();
 
             if (_DevicesCollection.find(uniqueId) != _DevicesCollection.end())

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -904,7 +904,7 @@ public:
         if (should_list)
         {
             cout << setw(4) << " Id ";
-            cout << setiosflags(ios::left) << setw(10) << "Pci Id    ";
+            cout << setiosflags(ios::left) << setw(13) << "Pci Id       ";
             cout << setw(5) << "Type ";
             cout << setw(30) << "Name                          ";
 
@@ -933,7 +933,7 @@ public:
 
             cout << resetiosflags(ios::left) << endl;
             cout << setw(4) << "--- ";
-            cout << setiosflags(ios::left) << setw(10) << "--------- ";
+            cout << setiosflags(ios::left) << setw(13) << "------------ ";
             cout << setw(5) << "---- ";
             cout << setw(30) << "----------------------------- ";
 
@@ -965,7 +965,7 @@ public:
             {
                 auto i = distance(m_DevicesCollection.begin(), it);
                 cout << setw(3) << i << " ";
-                cout << setiosflags(ios::left) << setw(10) << it->first;
+                cout << setiosflags(ios::left) << setw(13) << it->first;
                 cout << setw(5);
                 switch (it->second.type)
                 {


### PR DESCRIPTION
To properly identify all GPUs on a ppc64le system we need to pass the pciDomainID information to find all the GPU's available. If a GPU has the same pciBusID and pciDeviceID but different pciDomainID it fails to load one of them.

Without the patch:
```
[root@rhvpower nsfminer]# ./nsfminer -L
 Id Pci Id    Type Name                          CUDA SM   Total Memory 
--- --------- ---- ----------------------------- ---- ---  ------------ 
  0 03:00.0   Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 
  1 04:00.0   Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 
  2 05:00.0   Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 


[root@rhvpower nsfminer]# lspci | grep V100
0004:04:00.0 3D controller: NVIDIA Corporation GV100GL [Tesla V100 SXM2 16GB] (rev a1)
0004:05:00.0 3D controller: NVIDIA Corporation GV100GL [Tesla V100 SXM2 16GB] (rev a1)
0035:03:00.0 3D controller: NVIDIA Corporation GV100GL [Tesla V100 SXM2 16GB] (rev a1)
0035:04:00.0 3D controller: NVIDIA Corporation GV100GL [Tesla V100 SXM2 16GB] (rev a1)
```

With the patch:
```
[root@rhvpower nsfminer]# ./nsfminer -L
 Id Pci Id       Type Name                          CUDA SM   Total Memory 
--- ------------ ---- ----------------------------- ---- ---  ------------ 
  0 0004:04:00.0 Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 
  1 0004:05:00.0 Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 
  2 0035:03:00.0 Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 
  3 0035:04:00.0 Gpu  Tesla V100-SXM2-16GB          Yes  7.0      15.78 GB 
```