### PR TITLE
Revert "Add pciDomainID support for ppc64le systems"

### DIFF
--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -243,9 +243,8 @@ void CUDAMiner::enumDevices(map<string, DeviceDescriptor>& _DevicesCollection)
             size_t freeMem, totalMem;
             CUDA_CALL(cudaGetDeviceProperties(&props, i));
             CUDA_CALL(cudaMemGetInfo(&freeMem, &totalMem));
-            s << setw(4) << setfill('0') << hex << props.pciDomainID << ":" 
-              << setw(2) << setfill('0') << hex << props.pciBusID << ":"
-              << setw(2) << props.pciDeviceID << ".0";
+            s << setw(2) << setfill('0') << hex << props.pciBusID << ":" << setw(2)
+              << props.pciDeviceID << ".0";
             uniqueId = s.str();
 
             if (_DevicesCollection.find(uniqueId) != _DevicesCollection.end())

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -903,7 +903,7 @@ public:
         if (should_list)
         {
             cout << setw(4) << " Id ";
-            cout << setiosflags(ios::left) << setw(13) << "Pci Id       ";
+            cout << setiosflags(ios::left) << setw(10) << "Pci Id    ";
             cout << setw(5) << "Type ";
             cout << setw(30) << "Name                          ";
 
@@ -932,7 +932,7 @@ public:
 
             cout << resetiosflags(ios::left) << endl;
             cout << setw(4) << "--- ";
-            cout << setiosflags(ios::left) << setw(13) << "------------ ";
+            cout << setiosflags(ios::left) << setw(10) << "--------- ";
             cout << setw(5) << "---- ";
             cout << setw(30) << "----------------------------- ";
 
@@ -964,7 +964,7 @@ public:
             {
                 auto i = distance(m_DevicesCollection.begin(), it);
                 cout << setw(3) << i << " ";
-                cout << setiosflags(ios::left) << setw(13) << it->first;
+                cout << setiosflags(ios::left) << setw(10) << it->first;
                 cout << setw(5);
                 switch (it->second.type)
                 {


### PR DESCRIPTION
Had to revert your fix
```
jcyr@miner0:~$ nsfminer --list-devices
 Id Pci Id       Type Name                          CUDA SM  CL    Total Memory 
--- ------------ ---- ----------------------------- ---- --- ----  ------------ 
  0 0000:0a:00.0 Gpu  GeForce GTX 1060 6GB          Yes  6.1            5.94 GB 
  1 03:00.0      Gpu  gfx1010                                Yes        7.98 GB 
  2 0a:00.0      Gpu  GeForce GTX 1060 6GB                   Yes        5.94 GB 
  3 0e:00.0      Gpu  gfx900                                 Yes        7.98 GB 
```
Nvidia GPUs show up twice. Mining is attempted in both CUDA and OpenCl mode on same GPU.