### PR TITLE
Implement a pool reconnect scheme with a sleep timer when there's no failover pools defined

### DIFF
--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -375,11 +375,12 @@ void PoolManager::rotateConnect()
     }
     else if (m_connectionAttempt >= m_Settings.connectionMaxRetries)
     {
-        // If this is the only connection we can't rotate
-        // forever
+        // If this is the only connection sleep for 60 seconds and try again
         if (m_Settings.connections.size() == 1)
         {
-            m_Settings.connections.erase(m_Settings.connections.begin() + m_activeConnectionIdx);
+            cnote << "Sleeping for 60 seconds since the pool appears to be unreachable and there's no backup pools defined";
+            this_thread::sleep_until(chrono::system_clock::now() + chrono::seconds(60));
+            m_connectionAttempt = 0;
         }
         // Rotate connections if above max attempts threshold
         else

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -375,11 +375,11 @@ void PoolManager::rotateConnect()
     }
     else if (m_connectionAttempt >= m_Settings.connectionMaxRetries)
     {
-        // If this is the only connection sleep for 60 seconds and try again
+        // If this is the only connection sleep for "sleepTimeBeforeReconnect" seconds and try again
         if (m_Settings.connections.size() == 1)
         {
-            cnote << "Sleeping for 60 seconds since the pool appears to be unreachable and there's no backup pools defined";
-            this_thread::sleep_until(chrono::system_clock::now() + chrono::seconds(60));
+            cnote << "Sleeping for " << m_Settings.sleepTimeBeforeReconnect << " seconds since the pool appears to be unreachable and there's no backup pools defined";
+            this_thread::sleep_until(chrono::system_clock::now() + chrono::seconds(m_Settings.sleepTimeBeforeReconnect));
             m_connectionAttempt = 0;
         }
         // Rotate connections if above max attempts threshold

--- a/libpoolprotocols/PoolManager.h
+++ b/libpoolprotocols/PoolManager.h
@@ -23,16 +23,17 @@ struct PoolSettings
 {
     std::vector<std::shared_ptr<URI>> connections;  // List of connection definitions
     unsigned getWorkPollInterval = 500;             // Interval (ms) between getwork requests
-    unsigned noWorkTimeout = 180;       // If no new jobs in this number of seconds drop connection
-    unsigned noResponseTimeout = 2;     // If no response in this number of seconds drop connection
-    unsigned poolFailoverTimeout = 0;   // Return to primary pool after this number of minutes
-    bool reportHashrate = false;        // Whether or not to report hashrate to pool
-    unsigned hashRateInterval = 60;     // Interval in seconds among hashrate submissions
+    unsigned noWorkTimeout = 180;                   // If no new jobs in this number of seconds drop connection
+    unsigned noResponseTimeout = 2;                 // If no response in this number of seconds drop connection
+    unsigned poolFailoverTimeout = 0;               // Return to primary pool after this number of minutes
+    bool reportHashrate = false;                    // Whether or not to report hashrate to pool
+    unsigned hashRateInterval = 60;                 // Interval in seconds among hashrate submissions
     std::string hashRateId =
-        h256::random().hex(HexPrefix::Add);  // Unique identifier for HashRate submission
-    unsigned connectionMaxRetries = 3;  // Max number of connection retries
-    unsigned delayBeforeRetry = 0;      // Delay seconds before connect retry
-    unsigned benchmarkBlock = 0;        // Block number used by SimulateClient to test performances
+        h256::random().hex(HexPrefix::Add);         // Unique identifier for HashRate submission
+    unsigned connectionMaxRetries = 3;              // Max number of connection retries
+    unsigned delayBeforeRetry = 0;                  // Delay seconds before connect retry
+    unsigned sleepTimeBeforeReconnect = 60;         // Default sleep time (in seconds) for reconnection when no failover pools are used
+    unsigned benchmarkBlock = 0;                    // Block number used by SimulateClient to test performances
 };
 
 class PoolManager

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -456,6 +456,12 @@ public:
 
                 "Delay in seconds before reconnection retry")
 
+            ("sleep-time", value<unsigned>()->default_value(60),
+
+                "Defines the sleep time, in seconds, to wait before "
+                "trying to reconnect to the existing pool when there "
+                "is no failover pools defined.")
+
             ("work-timeout", value<unsigned>()->default_value(180),
 
                 "If no new work received from pool after this "
@@ -780,6 +786,7 @@ public:
         m_PoolSettings.getWorkPollInterval = vm["farm-recheck"].as<unsigned>();
         m_PoolSettings.connectionMaxRetries = vm["farm-retries"].as<unsigned>();
         m_PoolSettings.delayBeforeRetry = vm["retry-delay"].as<unsigned>();
+        m_PoolSettings.sleepTimeBeforeReconnect = vm["sleep-time"].as<unsigned>();
         m_PoolSettings.noWorkTimeout = vm["work-timeout"].as<unsigned>();
         m_PoolSettings.noResponseTimeout = vm["response-timeout"].as<unsigned>();
         m_PoolSettings.reportHashrate = vm.count("report-hashrate");


### PR DESCRIPTION
I need help with this PR.

I've been trying to implement a timer to wait before reconnecting to a given pool if the pool is unavailable instead of just quitting the miner for 3 days now.

The logic seems to be OK, but we're definitely hitting some race condition and I don't know how to debug it. So here's an exemple of the issue when the sleep timer variable is set to 3 seconds:

```
./nsfminer --cuda --pool stratum1+ssl://0xBE51363AC@eth.fakepool.lol:9433 --sleep-time 3
 miner nsfminer 1.3.1+commit.66d0712b.dirty (No stinkin' fees edition)
 miner Copyright 2021 Jean M. Cyr, Licensed under the terms
 miner  of the GNU General Public License Version 3
 miner https://github.com/no-fee-ethereum-mining/nsfminer
 miner Build: linux/release/gnu
 miner 3rd Party: GCC 8.3.1, CUDA 11.2, Boost 1.75.0
 miner 3rd Party: OpenSSL 1.1.1i, Ethash 0.5.0
 miner Configured pool eth.fakepool.lol:9433
 miner Selected pool eth.fakepool.lol:9433
 miner Could not resolve host eth.fakepool.lol, Host not found (authoritative)
 miner Disconnected from eth.fakepool.lol:9433
 miner No connection. Suspend mining ...
 miner Selected pool eth.fakepool.lol:9433
 miner Could not resolve host eth.fakepool.lol, Host not found (authoritative)
 miner Disconnected from eth.fakepool.lol:9433
 miner No connection. Suspend mining ...
 miner Selected pool eth.fakepool.lol:9433
 miner Could not resolve host eth.fakepool.lol, Host not found (authoritative)
 miner Disconnected from eth.fakepool.lol:9433
 miner No connection. Suspend mining ...
 miner Sleeping for 3 seconds since the pool appears to be unreachable and there's no backup pools defined
 miner Selected pool eth.fakepool.lol:9433
 miner Could not resolve host eth.fakepool.lol, Host not found (authoritative)
 miner Disconnected from eth.fakepool.lol:9433
 miner No connection. Suspend mining ...
 miner Selected pool eth.fakepool.lol:9433
 miner Could not resolve host eth.fakepool.lol, Host not found (authoritative)
 miner Disconnected from eth.fakepool.lol:9433
 miner No connection. Suspend mining ...
 miner Selected pool eth.fakepool.lol:9433
 miner Could not resolve host eth.fakepool.lol, Host not found (authoritative)
 miner Disconnected from eth.fakepool.lol:9433
 miner No connection. Suspend mining ...
 miner Sleeping for 3 seconds since the pool appears to be unreachable and there's no backup pools defined
 miner Selected pool eth.fakepool.lol:9433
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted (core dumped)
```

As you can see it fails to connect, them it warns and waits from 3 seconds, them it tries again, and finally we have an `std::logic_error`.

Since the software is threaded I think the sleep_until function is sleeping the thread and not the entire execution, but I'm not aware of a function that will sleep all threads. But again, this is just a guessing.

With observation I've noted that the crash time is about 5 seconds, so if the timer higher than 5 seconds it will always crash without even trying again.
