### PR TITLE
Preliminar macOS support for the CPUMiner

### DIFF
--- a/libeth/Miner.h
+++ b/libeth/Miner.h
@@ -322,7 +322,7 @@ public:
 
 protected:
     virtual bool initDevice() = 0;
-    virtual bool initEpoch() = 0;
+    virtual void initEpoch() = 0;
 
     WorkPackage work() const;
     void ReportSolution(const h256& header, uint64_t nonce);

--- a/libeth/Miner.h
+++ b/libeth/Miner.h
@@ -322,7 +322,7 @@ public:
 
 protected:
     virtual bool initDevice() = 0;
-    virtual void initEpoch() = 0;
+    virtual bool initEpoch() = 0;
 
     WorkPackage work() const;
     void ReportSolution(const h256& header, uint64_t nonce);


### PR DESCRIPTION
I've ported the CPUMiner to macOS.

Why I've done this? Because it's easier to test and develop things when the miner can at least connect to something on my main machine.

This is barely a preliminar effort, but it's working as expected, considering that we must adapt `libeth/Miner.h` for CPU mining on `virtual bool initEpoch() = 0;`.

At this moment there's no support for CPU affinity, it just issues a `cwarn` and ignores the affinity.

Seems to work:
```
➜  build git:(macos-support) ✗ ./nsfminer/nsfminer -R --cpu --pool stratum1+tcp://0xXXXXXXXXXXXXXX@eth-us-east1.nanopool.org:9999 
 miner nsfminer 1.3.2+commit.8ac7be5c.dirty (No stinkin' fees edition)
 miner Copyright 2021 Jean M. Cyr, Licensed under the terms
 miner  of the GNU General Public License Version 3
 miner https://github.com/no-fee-ethereum-mining/nsfminer
 miner Build: darwin/release/appleclang
 miner 3rd Party: GCC 12.0.0.12000032, Boost 1.75.0
 miner 3rd Party: OpenSSL 1.1.1i, Ethash 0.5.0
 miner Configured pool eth-us-east1.nanopool.org:9999
 <unknown> Selected pool eth-us-east1.nanopool.org:9999
 <unknown> Stratum mode : Eth-Proxy compatible
 <unknown> Established connection to eth-us-east1.nanopool.org:9999
 <unknown> Spinning up miners...
 cpu-0 Using CPU: 0 ethash::eval()/boost 1.75.0 Memory : 349.29 MB
 cpu-0 Thread affinity is not yet supported on macOS
 <unknown> Epoch : 393 Difficulty : 10.00 Gh
 <unknown> Job: 311c518b eth-us-east1.nanopool.org:9999
 <unknown> Job: 311c518b eth-us-east1.nanopool.org:9999
 <unknown> Job: 295fbe1e eth-us-east1.nanopool.org:9999
 <unknown> 0:00 A0 0.00 h - cp0 0.00
 <unknown> Job: 39185802 eth-us-east1.nanopool.org:9999
 <unknown> Job: d9dfd62c eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 6.56 h - cp0 6.56
 <unknown> Job: d05ca8a7 eth-us-east1.nanopool.org:9999
 <unknown> Job: 323eeda9 eth-us-east1.nanopool.org:9999
 <unknown> Job: b3e65254 eth-us-east1.nanopool.org:9999
 <unknown> Job: 751a7706 eth-us-east1.nanopool.org:9999
 <unknown> Job: 7941baee eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 461.86 h - cp0 461.86
 <unknown> Job: aaa3a29a eth-us-east1.nanopool.org:9999
 <unknown> Job: b51e57d4 eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 478.32 h - cp0 478.32
 <unknown> Job: a33252c5 eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 431.74 h - cp0 431.74
 <unknown> Job: f8ecc0a4 eth-us-east1.nanopool.org:9999
 <unknown> Job: 4af14d55 eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 457.23 h - cp0 457.23
 <unknown> Job: 26bc56a5 eth-us-east1.nanopool.org:9999
 <unknown> Job: ea279b50 eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 479.07 h - cp0 479.07
 <unknown> Job: 4645fdd4 eth-us-east1.nanopool.org:9999
 <unknown> Hung GPU 0 detected and reboot script failed!
 <unknown> 0:00 A0 480.89 h - cp0 480.89
 <unknown> Job: 9c5ce7de eth-us-east1.nanopool.org:9999
```
