### PR TITLE
Retry max

### DIFF
--- a/libcl/CLMiner.cpp
+++ b/libcl/CLMiner.cpp
@@ -265,14 +265,7 @@ struct SearchResults
     uint32_t count;
     uint32_t hashCount;
     uint32_t abort;
-    struct
-    {
-        uint32_t gid;
-        // Can't use h256 data type here since h256 contains
-        // more than raw data. Kernel returns raw mix hash.
-        uint32_t mix[8];
-        uint32_t pad[7];  // pad to 16 words for easy indexing
-    } rslt[c_maxSearchResults];
+    uint32_t gid[c_maxSearchResults];
 };
 
 void CLMiner::workLoop()
@@ -289,6 +282,8 @@ void CLMiner::workLoop()
     if (!initDevice())
         return;
 
+    m_queue->enqueueWriteBuffer(*m_searchBuffer, CL_FALSE, 0, sizeof(zerox3), zerox3);
+
     try
     {
         while (!shouldStop())
@@ -298,22 +293,11 @@ void CLMiner::workLoop()
 
             if (m_queue)
             {
-                // no need to read the abort flag.
-                m_queue->enqueueReadBuffer(*m_searchBuffer, CL_TRUE, offsetof(SearchResults, count),
-                    2 * sizeof(results.count), (void*)&results.count);
-                if (results.count)
-                {
-                    if (results.count > c_maxSearchResults)
-                    {
-                        results.count = c_maxSearchResults;
-                    }
-
-                    m_queue->enqueueReadBuffer(*m_searchBuffer, CL_TRUE, 0,
-                        results.count * sizeof(results.rslt[0]), (void*)&results);
-                }
-                // clean the solution count, hash count, and abort flag
-                m_queue->enqueueWriteBuffer(*m_searchBuffer, CL_FALSE,
-                    offsetof(SearchResults, count), sizeof(zerox3), zerox3);
+                // synchronize and read the results.
+                m_queue->enqueueReadBuffer(
+                    *m_searchBuffer, CL_TRUE, 0, sizeof(results), (void*)&results);
+                // clear the solution count, hash count, and abort flag
+                m_queue->enqueueWriteBuffer(*m_searchBuffer, CL_FALSE, 0, sizeof(zerox3), zerox3);
             }
             else
                 results.count = 0;
@@ -370,18 +354,15 @@ void CLMiner::workLoop()
             m_queue->enqueueNDRangeKernel(
                 m_searchKernel, cl::NullRange, batch_blocks, m_deviceDescriptor.clGroupSize);
 
-            if (results.count)
+            // Report results while the kernel is running.
+            if (results.count > c_maxSearchResults)
+                results.count = c_maxSearchResults;
+            for (uint32_t i = 0; i < results.count; i++)
             {
-                // Report results while the kernel is running.
-                for (uint32_t i = 0; i < results.count; i++)
-                {
-                    uint64_t nonce = current.startNonce + results.rslt[i].gid;
-                    h256 mix((::byte*)&results.rslt[i].mix, h256::ConstructFromPointer);
-
-                    Farm::f().submitProof(
-                        Solution{nonce, mix, current, chrono::steady_clock::now(), m_index});
-                    ReportSolution(current.header, nonce);
-                }
+                uint64_t nonce = current.startNonce + results.gid[i];
+                Farm::f().submitProof(
+                    Solution{nonce, h256(), current, chrono::steady_clock::now(), m_index});
+                ReportSolution(current.header, nonce);
             }
 
             current = w;  // kernel now processing newest work

--- a/libcl/CLMiner.cpp
+++ b/libcl/CLMiner.cpp
@@ -268,10 +268,11 @@ struct SearchResults
     uint32_t gid[c_maxSearchResults];
 };
 
+const static uint32_t zerox3[3] = {0, 0, 0};
+
 void CLMiner::workLoop()
 {
     // Memory for zero-ing buffers. Cannot be static or const because crashes on macOS.
-    static uint32_t zerox3[3] = {0, 0, 0};
 
     uint64_t startNonce = 0;
 
@@ -281,8 +282,6 @@ void CLMiner::workLoop()
 
     if (!initDevice())
         return;
-
-    m_queue->enqueueWriteBuffer(*m_searchBuffer, CL_FALSE, 0, sizeof(zerox3), zerox3);
 
     try
     {
@@ -811,6 +810,8 @@ bool CLMiner::initEpoch()
 
         // create mining buffers
         m_searchBuffer = new cl::Buffer(*m_context, CL_MEM_WRITE_ONLY, sizeof(SearchResults));
+        m_queue->enqueueWriteBuffer(*m_searchBuffer, CL_FALSE, 0, sizeof(zerox3), zerox3);
+
 
         m_dagKernel.setArg(1, *m_light);
         m_dagKernel.setArg(2, *m_dag[0]);

--- a/libcl/kernels/cl/ethash.cl
+++ b/libcl/kernels/cl/ethash.cl
@@ -258,12 +258,7 @@ struct SearchResults
     uint count;
     uint hashCount;
     volatile uint abort;
-    struct
-    {
-        uint gid;
-        uint mix[8];
-        uint pad[7];  // pad to 16 words for easy indexing
-    } rslt[MAX_OUTPUTS];
+    uint gid[MAX_OUTPUTS];
 };
 
 __attribute__((reqd_work_group_size(WORKSIZE, 1, 1))) __kernel void search(
@@ -310,8 +305,6 @@ __attribute__((reqd_work_group_size(WORKSIZE, 1, 1))) __kernel void search(
     state[22] = (uint2)(0);
     state[23] = (uint2)(0);
     state[24] = (uint2)(0);
-
-    uint2 mixhash[4];
 
     for (int pass = 0; pass < 2; ++pass)
     {
@@ -369,11 +362,6 @@ __attribute__((reqd_work_group_size(WORKSIZE, 1, 1))) __kernel void search(
             barrier(CLK_LOCAL_MEM_FENCE);
         }
 
-        mixhash[0] = state[8];
-        mixhash[1] = state[9];
-        mixhash[2] = state[10];
-        mixhash[3] = state[11];
-
         state[12] = as_uint2(0x0000000000000001UL);
         state[13] = (uint2)(0);
         state[14] = (uint2)(0);
@@ -396,15 +384,7 @@ __attribute__((reqd_work_group_size(WORKSIZE, 1, 1))) __kernel void search(
     {
         atomic_inc(&g_output->abort);
         uint slot = min(MAX_OUTPUTS - 1u, atomic_inc(&g_output->count));
-        g_output->rslt[slot].gid = gid;
-        g_output->rslt[slot].mix[0] = mixhash[0].s0;
-        g_output->rslt[slot].mix[1] = mixhash[0].s1;
-        g_output->rslt[slot].mix[2] = mixhash[1].s0;
-        g_output->rslt[slot].mix[3] = mixhash[1].s1;
-        g_output->rslt[slot].mix[4] = mixhash[2].s0;
-        g_output->rslt[slot].mix[5] = mixhash[2].s1;
-        g_output->rslt[slot].mix[6] = mixhash[3].s0;
-        g_output->rslt[slot].mix[7] = mixhash[3].s1;
+        g_output->gid[slot] = gid;
     }
 }
 

--- a/libcuda/dagger_shuffled.cuh
+++ b/libcuda/dagger_shuffled.cuh
@@ -15,7 +15,7 @@
 
 #define _PARALLEL_HASH 4
 
-DEV_INLINE bool compute_hash(uint64_t nonce, uint2* mix_hash)
+DEV_INLINE bool compute_hash(uint64_t nonce)
 {
     // sha3_512(header .. nonce)
     uint2 state[12];
@@ -105,11 +105,6 @@ DEV_INLINE bool compute_hash(uint64_t nonce, uint2* mix_hash)
     // keccak_256(keccak_512(header..nonce) .. mix);
     if (cuda_swab64(keccak_f1600_final(state)) > d_target)
         return true;
-
-    mix_hash[0] = state[8];
-    mix_hash[1] = state[9];
-    mix_hash[2] = state[10];
-    mix_hash[3] = state[11];
 
     return false;
 }

--- a/libcuda/ethash_cuda_miner_kernel.cu
+++ b/libcuda/ethash_cuda_miner_kernel.cu
@@ -30,24 +30,15 @@ __global__ void ethash_search(Search_results* g_output, uint64_t start_nonce)
     if (g_output->done)
         return;
     uint32_t const gid = blockIdx.x * blockDim.x + threadIdx.x;
-    uint2 mix[4];
-    bool r = compute_hash(start_nonce + gid, mix);
+    bool r = compute_hash(start_nonce + gid);
     if (threadIdx.x == 0)
-        atomicInc((uint32_t*)&g_output->counts.hashCount, 0xffffffff);
+        atomicInc((uint32_t*)&g_output->hashCount, 0xffffffff);
     if (r)
         return;
-    uint32_t index = atomicInc((uint32_t*)&g_output->counts.solCount, 0xffffffff);
+    uint32_t index = atomicInc((uint32_t*)&g_output->solCount, 0xffffffff);
     if (index >= MAX_SEARCH_RESULTS)
         return;
-    g_output->results[index].gid = gid;
-    g_output->results[index].mix[0] = mix[0].x;
-    g_output->results[index].mix[1] = mix[0].y;
-    g_output->results[index].mix[2] = mix[1].x;
-    g_output->results[index].mix[3] = mix[1].y;
-    g_output->results[index].mix[4] = mix[2].x;
-    g_output->results[index].mix[5] = mix[2].y;
-    g_output->results[index].mix[6] = mix[3].x;
-    g_output->results[index].mix[7] = mix[3].y;
+    g_output->gid[index] = gid;
     g_output->done = 1;
 }
 

--- a/libcuda/ethash_cuda_miner_kernel.h
+++ b/libcuda/ethash_cuda_miner_kernel.h
@@ -21,25 +21,12 @@
 // Leave room for up to 4 results. A power
 // of 2 here will yield better CUDA optimization
 #define MAX_SEARCH_RESULTS 4U
-
-struct Search_Result
-{
-    // One word for gid and 8 for mix hash
-    uint32_t gid;
-    uint32_t mix[8];
-    uint32_t pad[7];  // pad to size power of 2
-};
-
-struct count_pair
-{
-    uint32_t solCount, hashCount;
-};
-
 struct Search_results
 {
+    uint32_t solCount;
+    uint32_t hashCount;
     volatile uint32_t done;
-    struct count_pair counts;
-    Search_Result results[MAX_SEARCH_RESULTS];
+    uint32_t gid[MAX_SEARCH_RESULTS];
 };
 
 #define ACCESSES 64

--- a/libeth/Farm.cpp
+++ b/libeth/Farm.cpp
@@ -428,20 +428,15 @@ void Farm::submitProof(Solution const& _s)
 
 void Farm::submitProofAsync(Solution const& _s)
 {
-    if (m_Settings.eval)
+    Result r = EthashAux::eval(_s.work.epoch, _s.work.header, _s.nonce);
+    if (r.value > _s.work.boundary)
     {
-        Result r = EthashAux::eval(_s.work.epoch, _s.work.header, _s.nonce);
-        if (r.value > _s.work.boundary)
-        {
-            accountSolution(_s.midx, SolutionAccountingEnum::Failed);
-            cwarn << "GPU " << _s.midx
-                  << " gave incorrect result. Lower overclocking values if it happens frequently.";
-            return;
-        }
-        m_onSolutionFound(Solution{_s.nonce, r.mixHash, _s.work, _s.tstamp, _s.midx});
+        accountSolution(_s.midx, SolutionAccountingEnum::Failed);
+        cwarn << "GPU " << _s.midx
+              << " gave incorrect result. Lower overclocking values if it happens frequently.";
+        return;
     }
-    else
-        m_onSolutionFound(_s);
+    m_onSolutionFound(Solution{_s.nonce, r.mixHash, _s.work, _s.tstamp, _s.midx});
 
 #ifdef DEV_BUILD
     if (g_logOptions & LOG_SUBMIT)

--- a/libeth/Farm.h
+++ b/libeth/Farm.h
@@ -44,7 +44,6 @@ namespace eth
 {
 struct FarmSettings
 {
-    bool eval = false;        // Whether or not to re-evaluate solutions
     unsigned hwMon = 0;       // 0 - No monitor; 1 - Temp and Fan; 2 - Temp Fan Power
     unsigned tempStart = 40;  // Temperature threshold to restart mining (if paused)
     unsigned tempStop = 0;    // Temperature threshold to pause mining (overheating)

--- a/libpool/PoolManager.cpp
+++ b/libpool/PoolManager.cpp
@@ -378,23 +378,24 @@ void PoolManager::rotateConnect()
             m_activeConnectionIdx = 0;
         m_connectionSwitches.fetch_add(1, memory_order_relaxed);
     }
-    else if (m_connectionAttempt >= m_Settings.connectionMaxRetries)
+    else if (m_Settings.connections.size() == 1)
     {
         // If this is the only connection we can't rotate
         // forever
-        if (m_Settings.connections.size() == 1)
+        if (m_Settings.connectionMaxRetries &&
+            (m_connectionAttempt >= m_Settings.connectionMaxRetries))
         {
             m_Settings.connections.erase(m_Settings.connections.begin() + m_activeConnectionIdx);
         }
-        // Rotate connections if above max attempts threshold
-        else
-        {
-            m_connectionAttempt = 0;
-            m_activeConnectionIdx++;
-            if (m_activeConnectionIdx >= m_Settings.connections.size())
-                m_activeConnectionIdx = 0;
-            m_connectionSwitches.fetch_add(1, memory_order_relaxed);
-        }
+    }
+    // Rotate connections if above max attempts threshold
+    else
+    {
+        m_connectionAttempt = 0;
+        m_activeConnectionIdx++;
+        if (m_activeConnectionIdx >= m_Settings.connections.size())
+            m_activeConnectionIdx = 0;
+        m_connectionSwitches.fetch_add(1, memory_order_relaxed);
     }
 
     if (!m_Settings.connections.empty() &&

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -459,19 +459,20 @@ public:
 #endif
             )
 
-            ("farm-recheck", value<unsigned>()->default_value(500),
+            ("getwork-recheck", value<unsigned>()->default_value(500),
 
                 "Set polling interval for new work in getWork mode. "
                 "Value expressed in milliseconds. "
                 "It has no meaning in stratum mode")
 
-            ("farm-retries", value<unsigned>()->default_value(3),
-
-                "Set number of reconnection retries to same pool")
-
             ("retry-delay", value<unsigned>()->default_value(0),
 
                 "Delay in seconds before reconnection retry")
+
+            ("retry-max", value<unsigned>()->default_value(3),
+
+                "Set number of reconnection retries to same pool. "
+                "Set to 0 for infinite retries.")
 
             ("work-timeout", value<unsigned>()->default_value(180),
 
@@ -799,8 +800,8 @@ public:
         g_logSyslog = vm.count("syslog");
         g_exitOnError = vm.count("exit");
 
-        m_PoolSettings.getWorkPollInterval = vm["farm-recheck"].as<unsigned>();
-        m_PoolSettings.connectionMaxRetries = vm["farm-retries"].as<unsigned>();
+        m_PoolSettings.getWorkPollInterval = vm["getwork-recheck"].as<unsigned>();
+        m_PoolSettings.connectionMaxRetries = vm["retry-max"].as<unsigned>();
         m_PoolSettings.delayBeforeRetry = vm["retry-delay"].as<unsigned>();
         m_PoolSettings.noWorkTimeout = vm["work-timeout"].as<unsigned>();
         m_PoolSettings.noResponseTimeout = vm["response-timeout"].as<unsigned>();

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -531,11 +531,6 @@ public:
                 "Lists the detected OpenCL/CUDA devices and "
                 "exits. Can be combined with -G or -U flags")
 #endif
-            ("eval",
-                "Enable host software re-evaluation of GPUs "
-                "found nonces. Trims some ms. from submission "
-                "time but it may increase rejected solution rate.")
-
             ("tstop", value<unsigned>()->default_value(0),
 
                 "Suspend mining on GPU which temperature is above "
@@ -826,7 +821,6 @@ public:
                 m_devices.push_back(d);
 
         m_FarmSettings.hwMon = vm["HWMON"].as<unsigned>();
-        m_FarmSettings.eval = vm.count("eval");
         m_FarmSettings.nonce = vm["nonce"].as<string>();
 
 #if ETH_ETHASHCUDA


### PR DESCRIPTION
- rename --farm-recheck option to --getwork-recheck. It applies only to getwork protocol.
- rename --farm-retries option to --retry-max. Applies to both getwork and stratum protocols.
- Set --retry-max to 0 for unlimited retries.
