### PR TITLE
Fix potential GPU crash in stratum2 (nicehash)

### DIFF
--- a/libcl/CLMiner.cpp
+++ b/libcl/CLMiner.cpp
@@ -315,6 +315,7 @@ void CLMiner::workLoop()
             {
                 if (current.epoch != w.epoch)
                 {
+                    setEpoch(w);
                     if (!initEpoch())
                         break;
                     w = work();

--- a/libcpu/CPUMiner.cpp
+++ b/libcpu/CPUMiner.cpp
@@ -248,6 +248,7 @@ void CPUMiner::workLoop()
         // Epoch change ?
         if (current.epoch != w.epoch)
         {
+            setEpoch(w);
             initEpoch();
 
             // As DAG generation takes a while we need to

--- a/libeth/Farm.cpp
+++ b/libeth/Farm.cpp
@@ -167,21 +167,6 @@ void Farm::setWork(WorkPackage const& _newWp)
     // Set work to each miner giving it's own starting nonce
     unique_lock<mutex> l(farmWorkMutex);
 
-    // Retrieve appropriate EpochContext
-    if (m_currentWp.epoch != _newWp.epoch)
-    {
-        ethash::epoch_context _ec = ethash::get_global_epoch_context(_newWp.epoch);
-        m_currentEc.epochNumber = _newWp.epoch;
-        m_currentEc.lightNumItems = _ec.light_cache_num_items;
-        m_currentEc.lightSize = ethash::get_light_cache_size(_ec.light_cache_num_items);
-        m_currentEc.dagNumItems = _ec.full_dataset_num_items;
-        m_currentEc.dagSize = ethash::get_full_dataset_size(_ec.full_dataset_num_items);
-        m_currentEc.lightCache = _ec.light_cache;
-
-        for (auto const& miner : m_miners)
-            miner->setEpoch(m_currentEc);
-    }
-
     m_currentWp = _newWp;
 
     // Get the randomly selected nonce

--- a/libeth/Miner.cpp
+++ b/libeth/Miner.cpp
@@ -166,6 +166,16 @@ void Miner::updateHashRate(uint32_t _groupSize, uint32_t _increment) noexcept
     m_groupCount = 0;
 }
 
+void Miner::setEpoch(WorkPackage const& w)
+{
+    ethash::epoch_context ec = ethash::get_global_epoch_context(w.epoch);
+    m_epochContext.epochNumber = w.epoch;
+    m_epochContext.lightNumItems = ec.light_cache_num_items;
+    m_epochContext.lightSize = ethash::get_light_cache_size(ec.light_cache_num_items);
+    m_epochContext.dagNumItems = ec.full_dataset_num_items;
+    m_epochContext.dagSize = ethash::get_full_dataset_size(ec.full_dataset_num_items);
+    m_epochContext.lightCache = ec.light_cache;
+}
 
 }  // namespace eth
 }  // namespace dev

--- a/libeth/Miner.h
+++ b/libeth/Miner.h
@@ -305,7 +305,6 @@ public:
 
     DeviceDescriptor getDescriptor();
     void setWork(WorkPackage const& _work);
-    void setEpoch(EpochContext const& _ec) { m_epochContext = _ec; }
     unsigned Index() { return m_index; };
     HwMonitorInfo hwmonInfo() { return m_hwmoninfo; }
     void setHwmonDeviceIndex(int i) { m_hwmoninfo.deviceIndex = i; }
@@ -324,6 +323,8 @@ public:
 protected:
     virtual bool initDevice() = 0;
     virtual bool initEpoch() = 0;
+    void setEpoch(WorkPackage const& _newWp);
+
 
     WorkPackage work() const;
     void ReportSolution(const h256& header, uint64_t nonce);


### PR DESCRIPTION
- Fix potential GPU crash if new jobs arrive with different epochs in rapid succession. This can cause the light cache storage to be reallocated while the DAG is being generated.
