### PR TITLE
-fix read-me link for circleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Check our [samples](docs/POOL_EXAMPLES_ETH.md) to see how to connect to differen
 
 ### Master branch build status
 
-[![CircleCI](https://circleci.com/gh/no-fee-ethereum-mining/nsfminer.svg?style=svg)](https://circleci.com/gh/no-fee-ethereum-mining/fminer)
+[![CircleCI](https://circleci.com/gh/no-fee-ethereum-mining/nsfminer.svg?style=svg)](https://circleci.com/gh/no-fee-ethereum-mining/nsfminer)
 
 ### Building from source
 


### PR DESCRIPTION
I've noticed that the CircleCI link is wrong at readme.md

This pull request is to fix the link.