### PR TITLE
Prevent Windows from going to sleep while miner is active

### DIFF
--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -1205,6 +1205,9 @@ int main(int argc, char** argv)
         if (GetConsoleMode(hOut, &dwMode))
             SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
     }
+
+    // prevent system sleep
+    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_AWAYMODE_REQUIRED);
 #endif
 
     if (argc < 2)


### PR DESCRIPTION
It seems that if left unchecked, windows could go to sleep while miner is running. Adding `SetThreadExecutionState` seems to prevent that.

I'm not really a C developer, so do let me know if there is a better place to put it.