### PR TITLE
- use board name instead of architecture for AMD in --list-devices an…

### DIFF
--- a/libapi/ApiServer.cpp
+++ b/libapi/ApiServer.cpp
@@ -953,7 +953,7 @@ Json::Value ApiConnection::getMinerStatDetailPerMiner(
                 "GPU" :
                 (minerDescriptor.type == DeviceTypeEnum::Accelerator ? "ACCELERATOR" : "CPU"));
     ostringstream ss;
-    ss << (minerDescriptor.clDetected ? minerDescriptor.clName : minerDescriptor.cuName) << " "
+    ss << minerDescriptor.boardName << " "
        << dev::getFormattedMemory((double)minerDescriptor.totalMemory);
     hwinfo["name"] = ss.str();
 

--- a/libcpu/CPUMiner.cpp
+++ b/libcpu/CPUMiner.cpp
@@ -123,7 +123,7 @@ CPUMiner::~CPUMiner()
  */
 bool CPUMiner::initDevice()
 {
-    cnote << "Using CPU: " << m_deviceDescriptor.cpCpuNumer << " " << m_deviceDescriptor.name
+    cnote << "Using CPU: " << m_deviceDescriptor.cpCpuNumer << " " << m_deviceDescriptor.boardName
           << " Memory : " << dev::getFormattedMemory((double)m_deviceDescriptor.totalMemory);
 
 #if defined(__linux__)
@@ -289,7 +289,7 @@ void CPUMiner::enumDevices(map<string, DeviceDescriptor>& _DevicesCollection)
         s.clear();
         s << "ethash::eval()/boost " << (BOOST_VERSION / 100000) << "."
           << (BOOST_VERSION / 100 % 1000) << "." << (BOOST_VERSION % 100);
-        deviceDescriptor.name = s.str();
+        deviceDescriptor.boardName = s.str();
         deviceDescriptor.uniqueId = uniqueId;
         deviceDescriptor.type = DeviceTypeEnum::Cpu;
         deviceDescriptor.totalMemory = getTotalPhysAvailableMemory();

--- a/libcuda/CUDAMiner.cpp
+++ b/libcuda/CUDAMiner.cpp
@@ -34,7 +34,7 @@ CUDAMiner::~CUDAMiner()
 
 bool CUDAMiner::initDevice()
 {
-    cnote << "Using Pci " << m_deviceDescriptor.uniqueId << ": " << m_deviceDescriptor.cuName
+    cnote << "Using Pci " << m_deviceDescriptor.uniqueId << ": " << m_deviceDescriptor.boardName
           << " (Compute " + m_deviceDescriptor.cuCompute + ") Memory : "
           << dev::getFormattedMemory((double)m_deviceDescriptor.totalMemory);
 
@@ -282,13 +282,12 @@ void CUDAMiner::enumDevices(minerMap& _DevicesCollection)
             else
                 deviceDescriptor = DeviceDescriptor();
 
-            deviceDescriptor.name = string(props.name);
+            deviceDescriptor.boardName = string(props.name);
             deviceDescriptor.cuDetected = true;
             deviceDescriptor.uniqueId = uniqueId;
             deviceDescriptor.type = DeviceTypeEnum::Gpu;
             deviceDescriptor.cuDeviceIndex = i;
             deviceDescriptor.cuDeviceOrdinal = i;
-            deviceDescriptor.cuName = string(props.name);
             deviceDescriptor.totalMemory = totalMem;
             deviceDescriptor.cuCompute = (to_string(props.major) + "." + to_string(props.minor));
             deviceDescriptor.cuComputeMajor = props.major;

--- a/libeth/Miner.h
+++ b/libeth/Miner.h
@@ -125,12 +125,11 @@ struct DeviceDescriptor
 
     string uniqueId;     // For GPUs this is the PCI ID
     size_t totalMemory;  // Total memory available by device
-    string name;         // Device Name
+    string boardName;
 
     int cpCpuNumer;  // For CPU
 
     bool cuDetected;  // For CUDA detected devices
-    string cuName;
     unsigned int cuDeviceOrdinal;
     unsigned int cuDeviceIndex;
     string cuCompute;
@@ -148,11 +147,10 @@ struct DeviceDescriptor
     string clDeviceVersion;
     unsigned int clDeviceVersionMajor;
     unsigned int clDeviceVersionMinor;
-    string clBoardName;
     string clNvCompute;
+    string clArch;
     unsigned int clNvComputeMajor;
     unsigned int clNvComputeMinor;
-    string clName;
     unsigned int clPlatformId;
     string clPlatformName;
     ClPlatformTypeEnum clPlatformType = ClPlatformTypeEnum::Unknown;

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -1022,7 +1022,7 @@ public:
                 default:
                     break;
                 }
-                cout << setw(30) << (it->second.name).substr(0, 28);
+                cout << setw(30) << (it->second.boardName).substr(0, 28);
 #if ETH_ETHASHCUDA
                 if (m_minerType == MinerType::CUDA || m_minerType == MinerType::Mixed)
                 {


### PR DESCRIPTION
…d console display.