### PR TITLE
fix retry-max=0, did not wait conn delay

### DIFF
--- a/libpool/PoolManager.cpp
+++ b/libpool/PoolManager.cpp
@@ -387,7 +387,9 @@ void PoolManager::rotateConnect()
             m_Settings.connections.erase(m_Settings.connections.begin() + m_activeConnectionIdx);
     }
     // Rotate connections if above max attempts threshold
-    if (!m_Settings.connections.empty() && (m_connectionAttempt >= m_Settings.connectionMaxRetries))
+    if (!m_Settings.connections.empty() &&
+        m_Settings.connectionMaxRetries != 0 &&
+        (m_connectionAttempt >= m_Settings.connectionMaxRetries))
     {
         m_connectionAttempt = 0;
         m_activeConnectionIdx++;


### PR DESCRIPTION
While run with --retry-max 0 and connect to a non-existed address, the nsfminer will not wait retry delay seconds.

Before:
miner Selected pool localhost:9999
 miner Error  127.0.0.1:9999 [ Connection refused ]
 miner Error  127.0.0.1:9999 [ Connection refused ]
 miner No more IP addresses to try for host: localhost
 miner Disconnected from localhost:9999
 miner No connection. Suspend mining ...
 miner Selected pool localhost:9999

After:
miner CUDA Error : no CUDA-capable device is detected
 miner Configured pool localhost:9999
 miner Selected pool localhost:9999
 miner Error  127.0.0.1:9999 [ Connection refused ]
 miner Error  127.0.0.1:9999 [ Connection refused ]
 miner No more IP addresses to try for host: localhost
 miner Disconnected from localhost:9999
 miner No connection. Suspend mining ...
 miner Selected pool localhost:9999
 miner Next connection attempt in 3 seconds
