### PR TITLE
correct nv fan speed

### DIFF
--- a/libhwmon/wrapnvml.cpp
+++ b/libhwmon/wrapnvml.cpp
@@ -186,9 +186,16 @@ int wrap_nvml_get_mem_tempC(wrap_nvml_handle* nvmlh, int gpuindex, unsigned int*
     return 0;
 }
 
+/*
+ * nv_get_fanspeed
+ *   call the nvidia command to get fan speed. 
+ *      nvidia-settings -t -q  [fan:0]/GPUTargetFanSpeed
+ *   for this function to work, it must set environment variable:
+ *      export DISPLAY=:0
+ */
 int nv_get_fanspeed(int gpuindex, unsigned int *speed){
     FILE *fp;
-    // nvidia-settings -t -q  [fan:0]/GPUTargetFanSpeed
+    int rv = -1;
     char cmd[64] = {0}, buf[64] = {0};
     sprintf(cmd, "nvidia-settings -t -q [fan:%d]/GPUTargetFanSpeed", gpuindex);
 
@@ -196,14 +203,14 @@ int nv_get_fanspeed(int gpuindex, unsigned int *speed){
         return -1;
     }
 
-    while (fgets(buf, sizeof(buf), fp) != NULL) {
+    if (fgets(buf, sizeof(buf), fp) != NULL) {
         *speed = atoi(buf);
-        return 0;
+        rv = 0;
     }
 
     pclose(fp);
 
-    return -1;
+    return rv;
 }
 
 int wrap_nvml_get_fanpcnt(wrap_nvml_handle* nvmlh, int gpuindex, unsigned int* fanpcnt) {


### PR DESCRIPTION
the nv lib will report incorrect fan speed, so use nvidia-setting to get current fan speed.

it could be tested with options "--HWMON 2 --api-port -3333"

and open terminal to  run command to get fan speed:

echo '{"method": "miner_getstat1", "jsonrpc": "2.0", "id": 0 }' | nc -w 2 localhost 3333
