### PR TITLE
make client side validation of solutions optional

### DIFF
--- a/libeth/Farm.cpp
+++ b/libeth/Farm.cpp
@@ -351,14 +351,15 @@ void Farm::submitProof(Solution const& _s) {
 }
 
 void Farm::submitProofAsync(Solution const& _s) {
-    Result r = EthashAux::eval(_s.work.epoch, _s.work.header, _s.nonce);
-    if (r.value > _s.work.boundary) {
-        accountSolution(_s.midx, SolutionAccountingEnum::Failed);
-        cwarn << "GPU " << _s.midx << " gave incorrect result. Lower overclocking values if it happens frequently.";
-        return;
+    if (m_Settings.validate) {
+        Result r = EthashAux::eval(_s.work.epoch, _s.work.header, _s.nonce);
+        if (r.value > _s.work.boundary) {
+            accountSolution(_s.midx, SolutionAccountingEnum::Failed);
+            cwarn << "GPU " << _s.midx << " gave incorrect result. Lower overclocking values if it happens frequently.";
+            return;
+        }
     }
-    m_onSolutionFound(Solution{_s.nonce, r.mixHash, _s.work, _s.tstamp, _s.midx});
-
+    m_onSolutionFound(Solution{_s.nonce, _s.mixHash, _s.work, _s.tstamp, _s.midx});
 #ifdef DEV_BUILD
     if (g_logOptions & LOG_SUBMIT)
         cnote << "Submit time: "

--- a/libeth/Farm.h
+++ b/libeth/Farm.h
@@ -49,6 +49,7 @@ struct FarmSettings {
     unsigned cuStreams = 0;
     unsigned clGroupSize = 0;
     bool clSplit = false;
+    bool validate = false;
 };
 
 typedef std::map<string, DeviceDescriptor> minerMap;

--- a/nsfminer/main.cpp
+++ b/nsfminer/main.cpp
@@ -483,6 +483,11 @@ class MinerCLI {
                 "Use syslog appropriate output (drop timestamp "
                 "and channel prefix)")
 
+            ("validate",
+
+                "Validate solution before submitting")
+
+
 #if ETH_ETHASHCL || ETH_ETHASHCUDA || ETH_ETHASH_CPU
 
             ("list-devices,L",
@@ -793,6 +798,7 @@ class MinerCLI {
 
         m_FarmSettings.hwMon = vm["HWMON"].as<unsigned>();
         m_FarmSettings.nonce = vm["nonce"].as<string>();
+        m_FarmSettings.validate = vm.count("validate");
 
 #if ETH_ETHASHCUDA
         m_FarmSettings.cuBlockSize = vm["cu-block"].as<unsigned>();


### PR DESCRIPTION
Because pools check solutions anyway, the client side check can be omitted, to save some latency and energy.