### PR TITLE
Fix example Windows .bat in BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -122,6 +122,7 @@ if not exist "build\" mkdir "build\"
 
 rem For CUDA 9.x pass also `-T v140`
 cmake -G "Visual Studio 15 2017 Win64" -H. -Bbuild -DETHASHCL=ON -DETHASHCUDA=ON -DAPICORE=ON ..
+cd "build\"
 cmake --build . --config Release --target package
 
 endlocal


### PR DESCRIPTION
Provided example .bat script for Windows will throw `Error: could not load cache` if build is attempted before cd into build directory.

Let me know if you are okay with me generally modernizing / updating the windows related documentation as well.